### PR TITLE
replaces hidden with width/height to fix webkit gradient issue

### DIFF
--- a/src/SVGSprite.js
+++ b/src/SVGSprite.js
@@ -56,7 +56,7 @@ class SVGSprite {
 
     // cache spriteContent as global variable as getSvgSprite below is called in 
     // the function scope of the page instead of the SVGSprite class)
-    spriteContent = `<div hidden>${sprite.contents.toString('utf8')}</div>`;
+    spriteContent = `<div style="width: 0; height: 0;">${sprite.contents.toString('utf8')}</div>`;
     // fs.utimes('.', new Date(), new Date(), () => { });
   };
 


### PR DESCRIPTION
Safari and Chrome won't render an SVG linear gradient when the `hidden` attribute or `display: none` is set. This PR changes the sprite div to use inline CSS to set the width/height to zero as a work around.

Stackoverflow I found while tracking down why my SVGs weren't rendering: https://stackoverflow.com/a/51553541

Edit: great library and thank you!