### PR TITLE
Make sprite element wrapping optional

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,6 +2,7 @@ const path = require('path');
 const SVGSprite = require("./src/SVGSprite");
 
 module.exports = (eleventyConfig, options = {}) => {
+
   if (!options.path) {
     throw new Error("[eleventy-plugin-svg-sprite] path must be specified in plugin options");
   }
@@ -10,25 +11,26 @@ module.exports = (eleventyConfig, options = {}) => {
   let config = Object.assign(defaultOptions, options);
 
   let svgSpriteInstance = new SVGSprite(config);
+
   eleventyConfig.on('beforeBuild', async () => { await svgSpriteInstance.compile(config); });
 
   eleventyConfig.addShortcode(config.svgSpriteShortcode, svgSpriteInstance.getSvgSprite);
 
   eleventyConfig.addShortcode(config.svgShortcode, (name, classes, desc, location) => {
-    // "desc" and "location" attributes are required for accessibility and 
-    // Lighthouse validations and are hardcoded in the layouts to provide 
+
+    // "desc" and "location" attributes are required for accessibility and
+    // Lighthouse validations and are hardcoded in the layouts to provide
     // unique values as required by Lighthouse.
     if (!name) {
       throw new Error("[eleventy-plugin-svg-sprite] name of SVG must be specified");
     }
+
     const nameAttr = name;
     const classesAttr = `${config.globalClasses} ${classes || config.defaultClasses}`;
     const descAttr = desc || `${nameAttr} icon`;
     const locationAttr = location || 'content';
 
-    return `<svg class="${classesAttr}" aria-describedby="symbol-${nameAttr}-desc" aria-labelledby="symbol-${nameAttr}-desc" role="group">
-                <desc id="symbol-${nameAttr}-desc-${locationAttr}">${descAttr}</desc>
-                <use xlink:href="#svg-${nameAttr}"></use>
-            </svg>`;
+    return `<svg class="${classesAttr}" aria-describedby="symbol-${nameAttr}-desc" aria-labelledby="symbol-${nameAttr}-desc" role="group"><desc id="symbol-${nameAttr}-desc-${locationAttr}">${descAttr}</desc><use xlink:href="#svg-${nameAttr}"></use></svg>`;
+
   });
 };

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,10 +1,15 @@
-const path = require('path');
+const path = require("path");
 const SVGSprite = require("./src/SVGSprite");
 
-module.exports = (eleventyConfig, options = {}) => {
-
+/**
+ * @param {any} eleventyConfig
+ * @param {import(".").IOptions} options
+ */
+const plugin = (eleventyConfig, options = {}) => {
   if (!options.path) {
-    throw new Error("[eleventy-plugin-svg-sprite] path must be specified in plugin options");
+    throw new Error(
+      "[eleventy-plugin-svg-sprite] path must be specified in plugin options"
+    );
   }
 
   let defaultOptions = require("./src/options");
@@ -12,25 +17,37 @@ module.exports = (eleventyConfig, options = {}) => {
 
   let svgSpriteInstance = new SVGSprite(config);
 
-  eleventyConfig.on('beforeBuild', async () => { await svgSpriteInstance.compile(config); });
-
-  eleventyConfig.addShortcode(config.svgSpriteShortcode, svgSpriteInstance.getSvgSprite);
-
-  eleventyConfig.addShortcode(config.svgShortcode, (name, classes, desc, location) => {
-
-    // "desc" and "location" attributes are required for accessibility and
-    // Lighthouse validations and are hardcoded in the layouts to provide
-    // unique values as required by Lighthouse.
-    if (!name) {
-      throw new Error("[eleventy-plugin-svg-sprite] name of SVG must be specified");
-    }
-
-    const nameAttr = name;
-    const classesAttr = `${config.globalClasses} ${classes || config.defaultClasses}`;
-    const descAttr = desc || `${nameAttr} icon`;
-    const locationAttr = location || 'content';
-
-    return `<svg class="${classesAttr}" aria-describedby="symbol-${nameAttr}-desc" aria-labelledby="symbol-${nameAttr}-desc" role="group"><desc id="symbol-${nameAttr}-desc-${locationAttr}">${descAttr}</desc><use xlink:href="#svg-${nameAttr}"></use></svg>`;
-
+  eleventyConfig.on("beforeBuild", async () => {
+    await svgSpriteInstance.compile(config);
   });
+
+  eleventyConfig.addShortcode(
+    config.svgSpriteShortcode,
+    svgSpriteInstance.getSvgSprite
+  );
+
+  eleventyConfig.addShortcode(
+    config.svgShortcode,
+    (name, classes, desc, location) => {
+      // "desc" and "location" attributes are required for accessibility and
+      // Lighthouse validations and are hardcoded in the layouts to provide
+      // unique values as required by Lighthouse.
+      if (!name) {
+        throw new Error(
+          "[eleventy-plugin-svg-sprite] name of SVG must be specified"
+        );
+      }
+
+      const nameAttr = name;
+      const classesAttr = `${config.globalClasses} ${
+        classes || config.defaultClasses
+      }`;
+      const descAttr = desc || `${nameAttr} icon`;
+      const locationAttr = location || "content";
+
+      return `<svg class="${classesAttr}" aria-describedby="symbol-${nameAttr}-desc" aria-labelledby="symbol-${nameAttr}-desc" role="group"><desc id="symbol-${nameAttr}-desc-${locationAttr}">${descAttr}</desc><use xlink:href="#svg-${nameAttr}"></use></svg>`;
+    }
+  );
 };
+
+module.exports = plugin;

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Available on [npm](https://www.npmjs.com/package/eleventy-plugin-svg-sprite).
 npm install eleventy-plugin-svg-sprite --save-dev
 # OR
 yarn add eleventy-plugin-svg-sprite --dev
+# OR
+pnpm add -D eleventy-plugin-svg-sprite
 ```
 
 Open up your Eleventy config file (probably `.eleventy.js`) and add the plugin:
@@ -29,14 +31,15 @@ module.exports = function (eleventyConfig) {
 
 ## Config Options
 
-| Option             | Type              | Default                              | Description                                                                                                       |
-| ------------------ | ----------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
-| path               | String (required) | undefined                            | relative path to svg directory                                                                                    |
-| spriteConfig       | Object            | (see [options.js](./src/options.js)) | Options you want to pass to [svg-sprite](https://github.com/svg-sprite/svg-sprite)                                |
-| globalClasses      | String            | (empty string)                       | global classes for embedded SVGs (will not be overridden by [custom classes](#adding-custom-classes-to-your-svg)) |
-| defaultClasses     | String            | (empty string)                       | default classes for embedded SVGs (overridden by [custom classes](#adding-custom-classes-to-your-svg))            |
-| svgSpriteShortcode | String            | svgsprite                            | Customise shortcode used to embed SVG sprite (see [Including the SVG Sprite](#including-the-svg-sprite))          |
-| svgShortcode       | String            | svg                                  | Customise shortcode used to embed SVG content (see [Embedding SVG Content](#embedding-svg-content))               |
+| Option               | Type              | Default                              | Description                                                                                                                              |
+| -------------------- | ----------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `path`               | String (required) | undefined                            | relative path to svg directory                                                                                                           |
+| `spriteConfig`       | Object            | (see [options.js](./src/options.js)) | Options you want to pass to [svg-sprite](https://github.com/svg-sprite/svg-sprite)                                                       |
+| `spriteWrap`         | Object or `false` | `{ height: '0', width: '0' }`        | Optional element wrapper applied to the generated SVG sprite. Pass boolean `false` to disable. (see [sprite wrapping](#sprite-wrapping)) |
+| `globalClasses`      | String            | (empty string)                       | global classes for embedded SVGs (will not be overridden by [custom classes](#adding-custom-classes-to-your-svg))                        |
+| `defaultClasses`     | String            | (empty string)                       | default classes for embedded SVGs (overridden by [custom classes](#adding-custom-classes-to-your-svg))                                   |
+| `svgSpriteShortcode` | String            | svgsprite                            | Customise shortcode used to embed SVG sprite (see [Including the SVG Sprite](#including-the-svg-sprite))                                 |
+| `svgShortcode`       | String            | svg                                  | Customise shortcode used to embed SVG content (see [Embedding SVG Content](#embedding-svg-content))                                      |
 
 ## Usage
 
@@ -126,6 +129,32 @@ You can write your own SVG shortcode if you prefer. To make sure the SVG is refe
 eleventyConfig.addShortcode("icon", function (name) {
   return `<svg><use xlink:href="#svg-${name}"></use></svg>`;
 });
+```
+
+### Sprite Wrapping
+
+By default the generate SVG Sprite will be wrapped within a `<div style="width:0; height:0;"></div>` element. You can optionally override the defaults and apply your own custom inline styles to be applied.
+
+```js
+eleventyConfig.addPlugin(svgSprite, {
+  path: "./src/assets/svg", // relative path to SVG directory
+  spriteWrap: {
+    display: "none", // use display none
+  },
+});
+
+// => <div style="display:none;"><svg></svg></div>
+```
+
+If you do not wish to have the generated sprite wrapped then pass a boolean `false` value to `spriteWrap`
+
+```js
+eleventyConfig.addPlugin(svgSprite, {
+  path: "./src/assets/svg", // relative path to SVG directory
+  spriteWrap: false,
+});
+
+// => <svg></svg>
 ```
 
 ## Credits

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,102 @@
+import type { Config } from "svg-sprite";
+
+export declare interface IOptions {
+  /**
+   * Relative path to svg directory
+   *
+   * @default
+   * undefined
+   */
+  path: string;
+  /**
+   * Global classes for embedded SVGs.
+   *
+   * **WILL NOT BE OVERRIDDEN BY CUSTOM CLASSES**
+   *
+   * @default
+   * ""
+   */
+  globalClasses?: string;
+  /**
+   * Default classes for embedded SVGs
+   *
+   * **OVERRIDDEN BY CUSTOM CLASSES**
+   *
+   * @default
+   * ""
+   */
+  defaultClasses?: string;
+  /**
+   * Customise shortcode used to embed SVG sprite
+   *
+   * @default
+   * "svgsprite"
+   *
+   * @example
+   *
+   * // Nunjucks/Liquid
+   * {% svgsprite %}
+   *
+   * // Handlebars
+   * {{{ svgsprite }}}
+   *
+   * // 11ty.js
+   * ${this.svgsprite()}
+   */
+  svgSpriteShortcode?: string;
+  /**
+   * Customise shortcode used to embed SVG content
+   *
+   * @default
+   * "svgsprite"
+   *
+   * @example
+   *
+   * // Nunjucks/Liquid
+   * {% svg "demo" %}
+   *
+   * // Handlebars
+   * {{{ svg "demo" }}}
+   *
+   * // 11ty.js
+   * ${this.svg("demo")}
+   */
+  svgShortcode?: string;
+  /**
+   * Optional element wrapper styling to be applied to the generated SVG sprite.
+   * You can prevent element wrapping by passing a boolean `false` value.
+   *
+   * @default
+   *
+   * ```js
+   * {
+   * spriteWrap: {
+   *   height: '0',
+   *   width: '0'
+   *  }
+   * }
+   * ```
+   *
+   * ---
+   *
+   * **Default**
+   *
+   * ```html
+   * <!-- Sprite will be nested within a div -->
+   * <div style="width: 0; height: 0;">
+   *  <svg>...</svg>
+   * </div>
+   * ```
+   *
+   * **Disabled**
+   * ```html
+   * <!-- Sprite will not be apply a wrapped -->
+   * <svg></svg>
+   * ```
+   */
+  spriteWrap?: false | CSSStyleDeclaration;
+  /**
+   * Options you want to pass to [svg-sprite](https://github.com/svg-sprite/svg-sprite)
+   */
+  spriteConfig?: Config;
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "types": "index.d.ts",
   "main": ".eleventy.js",
   "scripts": {
     "demo": "cd demo/; npx @11ty/eleventy",

--- a/src/options.js
+++ b/src/options.js
@@ -1,27 +1,32 @@
-module.exports = {
+/**
+ * @type {import("..").IOptions}
+ */
+const options = {
   path: "",
   globalClasses: "",
   defaultClasses: "",
   svgSpriteShortcode: "svgsprite",
   svgShortcode: "svg",
-  spriteConfig:
-  {
+  spriteWrap: null, // defaults to { height: '0', width: '0' }
+  spriteConfig: {
     mode: {
       inline: true,
       symbol: {
-        sprite: 'sprite.svg',
+        sprite: "sprite.svg",
         example: false,
       },
     },
     shape: {
-      transform: ['svgo'],
+      transform: ["svgo"],
       id: {
-        generator: 'svg-%s',
+        generator: "svg-%s",
       },
     },
     svg: {
       xmlDeclaration: false,
       doctypeDeclaration: false,
     },
-  }
+  },
 };
+
+module.exports = options;


### PR DESCRIPTION
Not sure why you wanted to nest the generated sprite within an additional node. Either way, this PR makes that logic optional  or alternatively brings support for custom inline style. I've included types but they are pretty much useless until 11ty team brings support. 