### PR TITLE
Update the svg-sprite dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "glob": "^10.3.3",
     "lodash": "^4.17.21",
-    "svg-sprite": "2.0.0",
+    "svg-sprite": "2.0.4",
     "vinyl": "^3.0.0"
   }
 }


### PR DESCRIPTION
`svg-sprite` 2.0.0 has a dependency on `lodash.trim` 4.5.1 which is subject to a ReDoS vulnerability:

https://github.com/advisories/GHSA-29mw-wpgm-hmr9

`svg-sprite` 2.0.3 removes this dependency:

https://github.com/svg-sprite/svg-sprite/releases/tag/v2.0.3

The current v2.0.x release is 2.0.4 which also includes several fixes:

https://github.com/svg-sprite/svg-sprite/releases/tag/v2.0.4